### PR TITLE
Fix typo and add kind attribute in the metrics filter

### DIFF
--- a/content/01. guide/helm-chart-core.md
+++ b/content/01. guide/helm-chart-core.md
@@ -342,7 +342,7 @@ policy_report_result{artifact_tag="",score="",status="pass"} 1
 
 #### Metric Filter
 
-Configure the processed namespaces, sources, policies, severities and/or status for metrics to get rid of unnecessary metrics. You can either define exclude or include rules, with wildcard support, for each available filter and combine them as needed.
+Configure the processed namespaces, sources, policies, severities, kinds and/or status for metrics to get rid of unnecessary metrics. You can either define exclude or include rules, with wildcard support, for each available filter and combine them as needed.
 
 ```yaml [values.yaml]
 metrics:
@@ -354,6 +354,8 @@ metrics:
       include: ["Trivy*", "Kyverno"]
     status:
       exclude: ["skip"]
+    kinds:
+      exclude: ["Pod"]
 ```
 
 ### Priority Mapping

--- a/content/04. kyverno-plugin/development.md
+++ b/content/04. kyverno-plugin/development.md
@@ -59,5 +59,5 @@ go run main.go run -k ~/.kube/config
 ```bash
 make build
 
-./build/policyreporter run -k ~/.kube/config
+./build/kyverno-plugin run -k ~/.kube/config
 ```

--- a/content/04. kyverno-plugin/development.md
+++ b/content/04. kyverno-plugin/development.md
@@ -59,5 +59,5 @@ go run main.go run -k ~/.kube/config
 ```bash
 make build
 
-./build/kyverno-plugin run -k ~/.kube/config
+./build/policyreporter run -k ~/.kube/config
 ```


### PR DESCRIPTION
This Pull request includes following changes:

1. Fix the build name that is `policyreporter`
2. Add new attribute `kind` in the metrics filter. Related to [this Pull Request](https://github.com/kyverno/policy-reporter/pull/442). 

![image](https://github.com/kyverno/policy-reporter-docs/assets/22825645/2722573c-c672-40e1-a4fe-e875d81613da)

