### PR TITLE
Fix URL to Helm values

### DIFF
--- a/docs/getting-started/helm.md
+++ b/docs/getting-started/helm.md
@@ -20,7 +20,7 @@ The Policy Reporter Helm Chart is also available as an OCI artifact in the Kyver
 By default most available features are disabled. So it's up to the user to enable or configure the features needed. This approach reduces the required resources to a bare minimum.
 
 ::: tip
-See the complete [values.yaml](https://github.com/kyverno/policy-reporter/blob/3.x/charts/policy-reporter/values.yaml) for reference.
+See the complete [values.yaml](https://github.com/kyverno/policy-reporter/blob/main/charts/policy-reporter/values.yaml) for reference.
 :::
 
 ## Structure


### PR DESCRIPTION
The URL to the Helm values in the documentation is broken because the branch currently pointed to doesn't exist. Fixed the URL by pointing to the `main` branch which I believe is the correct branch.