### PR TITLE
Document serving Policy Reporter UI on a subpath

### DIFF
--- a/docs/getting-started/helm.md
+++ b/docs/getting-started/helm.md
@@ -92,11 +92,13 @@ Serve the API over a hostname with the integrated Ingress support. This is mainl
 ingress:
   enabled: true
   annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
   hosts:
     - host: domain.com
       paths:
         - path: '/(.*)'
+          pathType: ImplementationSpecific
 ```
 
 ## Policy Reporter UI
@@ -163,12 +165,33 @@ ui:
   ingress:
     enabled: true
     annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$1
     hosts:
       - host: domain.com
         paths:
           - path: '/(.*)'
+            pathType: ImplementationSpecific
 ```
+
+It is also possible to serve the Policy Reporter UI on a subpath by making appropriate changes to the ingress configuration. For example, if you wanted to serve the UI on `/policy-reporter-ui/`:
+
+```yaml
+ui:
+  enabled: true
+  ingress:
+    enabled: true
+    annotations:
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+    hosts:
+      - host: domain.com
+        paths:
+          - path: '/policy-reporter-ui/(.*)'
+            pathType: ImplementationSpecific
+```
+
+Importantly, the trailing slash _must_ be specified in order for the web resources to be fetched correctly, i.e, you must access the Policy Reporter UI at `http(s)://domain.com/policy-reporter-ui/`.
 
 ## Kyverno Plugin
 
@@ -247,11 +270,13 @@ plugin:
     ingress:
       enabled: true
       annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$1
       hosts:
         - host: domain.com
           paths:
             - path: '/(.*)'
+              pathType: ImplementationSpecific
 ```
 
 ## Trivy Plugin
@@ -318,11 +343,13 @@ plugin:
     ingress:
       enabled: true
       annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$1
       hosts:
         - host: domain.com
           paths:
             - path: '/(.*)'
+              pathType: ImplementationSpecific
 ```
 
 ## Monitoring

--- a/docs/getting-started/helm.md
+++ b/docs/getting-started/helm.md
@@ -92,7 +92,6 @@ Serve the API over a hostname with the integrated Ingress support. This is mainl
 ingress:
   enabled: true
   annotations:
-    nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
   hosts:
     - host: domain.com
@@ -165,7 +164,6 @@ ui:
   ingress:
     enabled: true
     annotations:
-      nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$1
     hosts:
       - host: domain.com
@@ -182,7 +180,6 @@ ui:
   ingress:
     enabled: true
     annotations:
-      nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$1
     hosts:
       - host: domain.com
@@ -270,7 +267,6 @@ plugin:
     ingress:
       enabled: true
       annotations:
-        nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/rewrite-target: /$1
       hosts:
         - host: domain.com
@@ -343,7 +339,6 @@ plugin:
     ingress:
       enabled: true
       annotations:
-        nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/rewrite-target: /$1
       hosts:
         - host: domain.com


### PR DESCRIPTION
- Document serving Policy Reporter UI on a subpath
- Add `pathType: ImplementationSpecific` field to all ingress configurations
- Fix indentation of some YAML keys in the Helm values