### PR TITLE
Intro: fix link to PolicyReports CRDs

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Policy Reporter adds observability and monitoring possibilities to you cluster security based on the [PolicyReport CRDs](https://github.com/kubernetes-sigs/wg-policy-prototypes/blob/master/policy-report/README.md).
+Policy Reporter adds observability and monitoring possibilities to you cluster security based on the [PolicyReport CRDs](https://github.com/openreports/reports-api/blob/main/docs/api-docs.md).
 
 It provides common features like
 


### PR DESCRIPTION
Being granted by a link to an archived repository (https://github.com/kubernetes-retired/wg-policy-prototypes/blob/master/policy-report/README.md) right from the start of the introduction feels a bit weird.

According to the archival note:

> The Policy Report API is now part of the [OpenReports Project](https://openreports.io/).

This PR replaces the archived link by a link to the replacing OpenReports doc.
